### PR TITLE
Implement debug.exception-trace sysctl for RISC-V

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -12,6 +12,7 @@ config RISCV
 	select GENERIC_ATOMIC64 if !64BIT || !RV_ATOMIC
 	select RV_ATOMIC if SMP
 	select RV_SYSRISCV_ATOMIC if !RV_ATOMIC
+	select SYSCTL_EXCEPTION_TRACE
 
 config MMU
 	def_bool y


### PR DESCRIPTION
This prints "segfault at ..." whenever a user process SEGVs.  As we don't have a
native GDB, this is often the easiest way to figure out what's going on.  These
printk()s are enabled by default, just like the are on x86.  The implementation
is mostly copied from x86.